### PR TITLE
User_허브 배송 담당자 지정/추가/삭제 기능 구현

### DIFF
--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -23,6 +23,12 @@ spring:
             - Path=/auth/**  # /auth/** 경로로 들어오는 요청을 이 라우트로 처리
           filters:
               - RewritePath=/auth/(?<segment>.*), /api/auth/$\{segment}  # /auth/** 경로를 /api/auth/**로 변경
+        - id: user-service  # 라우트 식별자
+          uri: lb://user-service  # 'user-service'라는 이름으로 로드 밸런싱된 서비스로 라우팅
+          predicates:
+            - Path=/users/**  # /users/** 경로로 들어오는 요청을 이 라우트로 처리
+          filters:
+            - RewritePath=/users/(?<segment>.*), /api/users/$\{segment}  # /users/** 경로를 /api/users/**로 변경
       discovery:
         locator:
           enabled: true  # 서비스 디스커버리를 통해 동적으로 라우트를 생성하도록 설정

--- a/user/src/main/java/com/springcloud/client/user/application/DeliveryFacade.java
+++ b/user/src/main/java/com/springcloud/client/user/application/DeliveryFacade.java
@@ -1,0 +1,17 @@
+package com.springcloud.client.user.application;
+
+import com.springcloud.client.user.domain.DeliveryInfo;
+import com.springcloud.client.user.domain.DeliveryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryFacade {
+
+    private final DeliveryService deliveryService;
+
+    public DeliveryInfo getHubDeliveryDriver() {
+        return deliveryService.getHubDeliveryDriver();
+    }
+}

--- a/user/src/main/java/com/springcloud/client/user/application/DeliveryFacade.java
+++ b/user/src/main/java/com/springcloud/client/user/application/DeliveryFacade.java
@@ -19,4 +19,8 @@ public class DeliveryFacade {
     public DeliveryInfo getHubDeliveryDriver() {
         return deliveryService.getHubDeliveryDriver();
     }
+
+    public void deleteHubDeliveryDriver(DeliveryCommand command) {
+        deliveryService.deleteHubDeliveryDriver(command);
+    }
 }

--- a/user/src/main/java/com/springcloud/client/user/application/DeliveryFacade.java
+++ b/user/src/main/java/com/springcloud/client/user/application/DeliveryFacade.java
@@ -1,5 +1,6 @@
 package com.springcloud.client.user.application;
 
+import com.springcloud.client.user.domain.DeliveryCommand;
 import com.springcloud.client.user.domain.DeliveryInfo;
 import com.springcloud.client.user.domain.DeliveryService;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,10 @@ import org.springframework.stereotype.Service;
 public class DeliveryFacade {
 
     private final DeliveryService deliveryService;
+
+    public DeliveryInfo addHubDeliveryDriver(DeliveryCommand command) {
+        return deliveryService.addHubDeliveryDriver(command);
+    }
 
     public DeliveryInfo getHubDeliveryDriver() {
         return deliveryService.getHubDeliveryDriver();

--- a/user/src/main/java/com/springcloud/client/user/config/NgrokConfig.java
+++ b/user/src/main/java/com/springcloud/client/user/config/NgrokConfig.java
@@ -1,0 +1,4 @@
+package com.springcloud.client.user.config;
+
+public class NgrokConfig {
+}

--- a/user/src/main/java/com/springcloud/client/user/config/NgrokConfig.java
+++ b/user/src/main/java/com/springcloud/client/user/config/NgrokConfig.java
@@ -1,4 +1,35 @@
 package com.springcloud.client.user.config;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
 public class NgrokConfig {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private static final String DEFAULT_HOST = "localhost:19099"; // 예외 발생 시 사용할 기본 값
+
+    @PostConstruct
+    public void init() {
+        try {
+            RestTemplate restTemplate = new RestTemplate();
+            String response = restTemplate.getForObject("http://127.0.0.1:4040/api/tunnels", String.class);
+
+            // JSON 파싱 (Jackson 사용)
+            JsonNode jsonNode = objectMapper.readTree(response);
+            String ngrokUrl = jsonNode.path("tunnels").get(0).path("public_url").asText();
+
+            // Ngrok URL을 환경 변수로 설정
+            System.setProperty("My_host", ngrokUrl.replace("https://", "").replace("http://", ""));
+
+            System.out.println("Ngrok URL 설정 완료: " + ngrokUrl);
+        } catch (Exception e) {
+            // 예외 발생 시 기본 호스트 값 설정
+            System.setProperty("My_host", DEFAULT_HOST);
+            System.err.println("Ngrok URL을 가져오는 데 실패하여 기본값(" + DEFAULT_HOST + ")을 사용합니다. 오류: " + e.getMessage());
+        }
+    }
 }

--- a/user/src/main/java/com/springcloud/client/user/domain/DeliveryAssignment.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/DeliveryAssignment.java
@@ -1,0 +1,24 @@
+package com.springcloud.client.user.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Getter
+@Table(name = "p_delivery_assignment")
+public class DeliveryAssignment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Comment("PK")
+    private Integer deliveryAssignmentId;
+
+    @Column(nullable = false)
+    @Comment("현재 배송 담당자 인덱스")
+    private int currentDriverIndex;
+
+    public void updateCurrentDriverIndex(int newIndex) {
+        this.currentDriverIndex = newIndex;
+    }
+}

--- a/user/src/main/java/com/springcloud/client/user/domain/DeliveryCommand.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/DeliveryCommand.java
@@ -1,0 +1,21 @@
+package com.springcloud.client.user.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Builder
+@Getter
+public class DeliveryCommand {
+
+    private UUID userId;
+
+    public DeliveryDriver toEntity(User user, int deliveryOrderNumber) {
+        return DeliveryDriver.builder()
+                .user(user)
+                .deliveryOrderNumber(deliveryOrderNumber)
+                .role(DeliveryDriverRole.HUB)
+                .build();
+    }
+}

--- a/user/src/main/java/com/springcloud/client/user/domain/DeliveryDriver.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/DeliveryDriver.java
@@ -1,0 +1,35 @@
+package com.springcloud.client.user.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.hibernate.annotations.Comment;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Table(name = "p_delivery_driver")
+public class DeliveryDriver {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Comment("PK")
+    private UUID deliveryDriverId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Comment("소속 허브 ID (허브 배송 기사인 경우 null)")
+    @Column(nullable = true)
+    private UUID hubId;
+
+    @Comment("배송 순번 (0부터 시작, 순차 배정)")
+    @Column(nullable = false)
+    private int deliveryOrderNumber;
+
+    @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    @Comment("배송 기사 권한")
+    private DeliveryDriverRole role;
+}

--- a/user/src/main/java/com/springcloud/client/user/domain/DeliveryDriver.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/DeliveryDriver.java
@@ -1,12 +1,18 @@
 package com.springcloud.client.user.domain;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 
 import java.util.UUID;
 
 @Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Getter
 @Table(name = "p_delivery_driver")
 public class DeliveryDriver {

--- a/user/src/main/java/com/springcloud/client/user/domain/DeliveryDriver.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/DeliveryDriver.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 @AllArgsConstructor
 @Getter
 @Table(name = "p_delivery_driver")
-public class DeliveryDriver {
+public class DeliveryDriver extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)

--- a/user/src/main/java/com/springcloud/client/user/domain/DeliveryDriverRole.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/DeliveryDriverRole.java
@@ -1,0 +1,18 @@
+package com.springcloud.client.user.domain;
+
+public enum DeliveryDriverRole {
+
+    HUB(DeliveryDriverRole.Authority.HUB),
+    COMPANY(DeliveryDriverRole.Authority.COMPANY);
+
+    private final String authority;
+
+    DeliveryDriverRole(String authority) {
+        this.authority = authority;
+    }
+
+    public static class Authority {
+        public static final String HUB = "ROLE_HUB";
+        public static final String COMPANY = "ROLE_COMPANY";
+    }
+}

--- a/user/src/main/java/com/springcloud/client/user/domain/DeliveryInfo.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/DeliveryInfo.java
@@ -1,0 +1,21 @@
+package com.springcloud.client.user.domain;
+
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class DeliveryInfo {
+
+    private final UUID deliveryDriverId;
+    private final String username;
+    private final String slackId;
+    private final DeliveryDriverRole role;
+
+    public DeliveryInfo(DeliveryDriver deliveryDriver) {
+        this.deliveryDriverId = deliveryDriver.getDeliveryDriverId();
+        this.username = deliveryDriver.getUser().getUsername();
+        this.slackId = deliveryDriver.getUser().getSlackId();
+        this.role = deliveryDriver.getRole();
+    }
+}

--- a/user/src/main/java/com/springcloud/client/user/domain/DeliveryReader.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/DeliveryReader.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 public interface DeliveryReader {
 
+    Integer findMaxDeliveryOrderNumberByRole(DeliveryDriverRole deliveryDriverRole);
+
     List<DeliveryDriver> findAllByRoleOrderByDeliveryOrderNumberAsc(DeliveryDriverRole role);
 
     DeliveryAssignment findWithLock(int pk);

--- a/user/src/main/java/com/springcloud/client/user/domain/DeliveryReader.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/DeliveryReader.java
@@ -1,6 +1,8 @@
 package com.springcloud.client.user.domain;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface DeliveryReader {
 
@@ -9,4 +11,6 @@ public interface DeliveryReader {
     List<DeliveryDriver> findAllByRoleOrderByDeliveryOrderNumberAsc(DeliveryDriverRole role);
 
     DeliveryAssignment findWithLock(int pk);
+
+    Optional<DeliveryDriver> findById(UUID userId);
 }

--- a/user/src/main/java/com/springcloud/client/user/domain/DeliveryReader.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/DeliveryReader.java
@@ -1,0 +1,10 @@
+package com.springcloud.client.user.domain;
+
+import java.util.List;
+
+public interface DeliveryReader {
+
+    List<DeliveryDriver> findAllByRoleOrderByDeliveryOrderNumberAsc(DeliveryDriverRole role);
+
+    DeliveryAssignment findWithLock(int pk);
+}

--- a/user/src/main/java/com/springcloud/client/user/domain/DeliveryService.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/DeliveryService.java
@@ -47,4 +47,12 @@ public class DeliveryService {
 
         return new DeliveryInfo(deliveryDriver);
     }
+
+    public void deleteHubDeliveryDriver(DeliveryCommand command) {
+        DeliveryDriver deliveryDriver = deliveryReader.findById(command.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        deliveryDriver.delete();
+        deliveryStore.save(deliveryDriver);
+    }
 }

--- a/user/src/main/java/com/springcloud/client/user/domain/DeliveryService.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/DeliveryService.java
@@ -1,0 +1,35 @@
+package com.springcloud.client.user.domain;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryService {
+
+    private final DeliveryReader deliveryReader;
+    private final DeliveryStore deliveryStore;
+    private static final int PK_FOR_HUB_DELIVERY_DRIVER_INDEX = 1;
+
+    @Transactional
+    public DeliveryInfo getHubDeliveryDriver() {
+        List<DeliveryDriver> drivers = deliveryReader.findAllByRoleOrderByDeliveryOrderNumberAsc(DeliveryDriverRole.HUB);
+
+        if (drivers.isEmpty()) {
+            throw new IllegalStateException("등록된 허브 배송 담당자가 없습니다.");
+        }
+
+        DeliveryAssignment assignment = deliveryReader.findWithLock(PK_FOR_HUB_DELIVERY_DRIVER_INDEX);
+
+        DeliveryDriver deliveryDriver = drivers.get(assignment.getCurrentDriverIndex());
+
+        int nextDriverIndex = (assignment.getCurrentDriverIndex() + 1) % drivers.size();
+        assignment.updateCurrentDriverIndex(nextDriverIndex);
+        deliveryStore.save(assignment);
+
+        return new DeliveryInfo(deliveryDriver);
+    }
+}

--- a/user/src/main/java/com/springcloud/client/user/domain/DeliveryService.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/DeliveryService.java
@@ -12,7 +12,22 @@ public class DeliveryService {
 
     private final DeliveryReader deliveryReader;
     private final DeliveryStore deliveryStore;
+    private final UserReader userReader;
     private static final int PK_FOR_HUB_DELIVERY_DRIVER_INDEX = 1;
+
+    @Transactional
+    public DeliveryInfo addHubDeliveryDriver(DeliveryCommand command) {
+        User user = userReader.findById(command.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        Integer maxOrderNumber = deliveryReader.findMaxDeliveryOrderNumberByRole(DeliveryDriverRole.HUB);
+        int newOrderNumber = (maxOrderNumber == null) ? 0 : maxOrderNumber + 1;
+
+        DeliveryDriver deliveryDriver = command.toEntity(user, newOrderNumber);
+
+        DeliveryDriver savedDriver = deliveryStore.save(deliveryDriver);
+        return new DeliveryInfo(savedDriver);
+    }
 
     @Transactional
     public DeliveryInfo getHubDeliveryDriver() {

--- a/user/src/main/java/com/springcloud/client/user/domain/DeliveryStore.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/DeliveryStore.java
@@ -1,0 +1,6 @@
+package com.springcloud.client.user.domain;
+
+public interface DeliveryStore {
+
+    void save(DeliveryAssignment assignment);
+}

--- a/user/src/main/java/com/springcloud/client/user/domain/DeliveryStore.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/DeliveryStore.java
@@ -2,5 +2,7 @@ package com.springcloud.client.user.domain;
 
 public interface DeliveryStore {
 
+    DeliveryDriver save(DeliveryDriver driver);
+
     void save(DeliveryAssignment assignment);
 }

--- a/user/src/main/java/com/springcloud/client/user/domain/User.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/User.java
@@ -38,4 +38,7 @@ public class User extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     @Comment("사용자 권한")
     private UserRole role;
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, optional = true)
+    private DeliveryDriver deliveryDriver;
 }

--- a/user/src/main/java/com/springcloud/client/user/domain/UserReader.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/UserReader.java
@@ -1,8 +1,11 @@
 package com.springcloud.client.user.domain;
 
 import java.util.Optional;
+import java.util.UUID;
 
 public interface UserReader {
+
+    Optional<User> findById(UUID userId);
 
     Optional<User> findByUsername(String username);
 }

--- a/user/src/main/java/com/springcloud/client/user/infrastructure/DeliveryAssignmentRepository.java
+++ b/user/src/main/java/com/springcloud/client/user/infrastructure/DeliveryAssignmentRepository.java
@@ -1,0 +1,15 @@
+package com.springcloud.client.user.infrastructure;
+
+import com.springcloud.client.user.domain.DeliveryAssignment;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface DeliveryAssignmentRepository extends JpaRepository<DeliveryAssignment, Integer> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT da FROM DeliveryAssignment da WHERE da.deliveryAssignmentId = :id")
+    DeliveryAssignment findWithLock(@Param("id") Integer id);
+}

--- a/user/src/main/java/com/springcloud/client/user/infrastructure/DeliveryReaderImpl.java
+++ b/user/src/main/java/com/springcloud/client/user/infrastructure/DeliveryReaderImpl.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -29,5 +31,10 @@ public class DeliveryReaderImpl implements DeliveryReader {
     @Override
     public DeliveryAssignment findWithLock(int pk) {
         return deliveryAssignmentRepository.findWithLock(pk);
+    }
+
+    @Override
+    public Optional<DeliveryDriver> findById(UUID userId) {
+        return deliveryRepository.findById(userId);
     }
 }

--- a/user/src/main/java/com/springcloud/client/user/infrastructure/DeliveryReaderImpl.java
+++ b/user/src/main/java/com/springcloud/client/user/infrastructure/DeliveryReaderImpl.java
@@ -1,0 +1,28 @@
+package com.springcloud.client.user.infrastructure;
+
+import com.springcloud.client.user.domain.DeliveryAssignment;
+import com.springcloud.client.user.domain.DeliveryDriver;
+import com.springcloud.client.user.domain.DeliveryDriverRole;
+import com.springcloud.client.user.domain.DeliveryReader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryReaderImpl implements DeliveryReader {
+
+    private final DeliveryRepository deliveryRepository;
+    private final DeliveryAssignmentRepository deliveryAssignmentRepository;
+
+    @Override
+    public List<DeliveryDriver> findAllByRoleOrderByDeliveryOrderNumberAsc(DeliveryDriverRole role) {
+        return deliveryRepository.findAllByRoleOrderByDeliveryOrderNumberAsc(role);
+    }
+
+    @Override
+    public DeliveryAssignment findWithLock(int pk) {
+        return deliveryAssignmentRepository.findWithLock(pk);
+    }
+}

--- a/user/src/main/java/com/springcloud/client/user/infrastructure/DeliveryReaderImpl.java
+++ b/user/src/main/java/com/springcloud/client/user/infrastructure/DeliveryReaderImpl.java
@@ -17,6 +17,11 @@ public class DeliveryReaderImpl implements DeliveryReader {
     private final DeliveryAssignmentRepository deliveryAssignmentRepository;
 
     @Override
+    public Integer findMaxDeliveryOrderNumberByRole(DeliveryDriverRole role) {
+        return deliveryRepository.findMaxDeliveryOrderNumberByRole(role);
+    }
+
+    @Override
     public List<DeliveryDriver> findAllByRoleOrderByDeliveryOrderNumberAsc(DeliveryDriverRole role) {
         return deliveryRepository.findAllByRoleOrderByDeliveryOrderNumberAsc(role);
     }

--- a/user/src/main/java/com/springcloud/client/user/infrastructure/DeliveryRepository.java
+++ b/user/src/main/java/com/springcloud/client/user/infrastructure/DeliveryRepository.java
@@ -1,0 +1,13 @@
+package com.springcloud.client.user.infrastructure;
+
+import com.springcloud.client.user.domain.DeliveryDriver;
+import com.springcloud.client.user.domain.DeliveryDriverRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface DeliveryRepository extends JpaRepository<DeliveryDriver, UUID> {
+
+    List<DeliveryDriver> findAllByRoleOrderByDeliveryOrderNumberAsc(DeliveryDriverRole role);
+}

--- a/user/src/main/java/com/springcloud/client/user/infrastructure/DeliveryRepository.java
+++ b/user/src/main/java/com/springcloud/client/user/infrastructure/DeliveryRepository.java
@@ -3,11 +3,18 @@ package com.springcloud.client.user.infrastructure;
 import com.springcloud.client.user.domain.DeliveryDriver;
 import com.springcloud.client.user.domain.DeliveryDriverRole;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.UUID;
 
 public interface DeliveryRepository extends JpaRepository<DeliveryDriver, UUID> {
 
+    // Role이 HUB인 배송 기사들 중 최대 deliveryOrderNumber 조회
+    @Query("SELECT MAX(dd.deliveryOrderNumber) FROM DeliveryDriver dd WHERE dd.role = :role")
+    Integer findMaxDeliveryOrderNumberByRole(@Param("role") DeliveryDriverRole role);
+
+    // Role이 HUB인 배송 기사들을 deliveryOrderNumber 순으로 조회
     List<DeliveryDriver> findAllByRoleOrderByDeliveryOrderNumberAsc(DeliveryDriverRole role);
 }

--- a/user/src/main/java/com/springcloud/client/user/infrastructure/DeliveryStoreImpl.java
+++ b/user/src/main/java/com/springcloud/client/user/infrastructure/DeliveryStoreImpl.java
@@ -1,0 +1,19 @@
+package com.springcloud.client.user.infrastructure;
+
+import com.springcloud.client.user.domain.DeliveryAssignment;
+import com.springcloud.client.user.domain.DeliveryStore;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryStoreImpl implements DeliveryStore {
+
+    private final DeliveryRepository deliveryRepository;
+    private final DeliveryAssignmentRepository deliveryAssignmentRepository;
+
+    @Override
+    public void save(DeliveryAssignment assignment) {
+        deliveryAssignmentRepository.save(assignment);
+    }
+}

--- a/user/src/main/java/com/springcloud/client/user/infrastructure/DeliveryStoreImpl.java
+++ b/user/src/main/java/com/springcloud/client/user/infrastructure/DeliveryStoreImpl.java
@@ -1,6 +1,7 @@
 package com.springcloud.client.user.infrastructure;
 
 import com.springcloud.client.user.domain.DeliveryAssignment;
+import com.springcloud.client.user.domain.DeliveryDriver;
 import com.springcloud.client.user.domain.DeliveryStore;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -11,6 +12,11 @@ public class DeliveryStoreImpl implements DeliveryStore {
 
     private final DeliveryRepository deliveryRepository;
     private final DeliveryAssignmentRepository deliveryAssignmentRepository;
+
+    @Override
+    public DeliveryDriver save(DeliveryDriver driver) {
+        return deliveryRepository.save(driver);
+    }
 
     @Override
     public void save(DeliveryAssignment assignment) {

--- a/user/src/main/java/com/springcloud/client/user/infrastructure/UserReaderImpl.java
+++ b/user/src/main/java/com/springcloud/client/user/infrastructure/UserReaderImpl.java
@@ -6,12 +6,18 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
 public class UserReaderImpl implements UserReader {
 
     private final UserRepository userRepository;
+
+    @Override
+    public Optional<User> findById(UUID userId) {
+        return userRepository.findById(userId);
+    }
 
     @Override
     public Optional<User> findByUsername(String username) {

--- a/user/src/main/java/com/springcloud/client/user/interfaces/DeliveryController.java
+++ b/user/src/main/java/com/springcloud/client/user/interfaces/DeliveryController.java
@@ -28,4 +28,11 @@ public class DeliveryController {
         DeliveryDriverDto.DeliveryDriverResponse response = new DeliveryDriverDto.DeliveryDriverResponse(info);
         return ResponseEntity.ok(response);
     }
+
+    @PatchMapping("/hub-delivery-driver")
+    public ResponseEntity<Void> deleteHubDeliveryDriver(@RequestBody DeliveryDriverDto.DeliveryDriverRequest request) {
+        DeliveryCommand command = request.toCommand();
+        deliveryFacade.deleteHubDeliveryDriver(command);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/user/src/main/java/com/springcloud/client/user/interfaces/DeliveryController.java
+++ b/user/src/main/java/com/springcloud/client/user/interfaces/DeliveryController.java
@@ -1,0 +1,24 @@
+package com.springcloud.client.user.interfaces;
+
+import com.springcloud.client.user.application.DeliveryFacade;
+import com.springcloud.client.user.domain.DeliveryInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class DeliveryController {
+
+    private final DeliveryFacade deliveryFacade;
+
+    @GetMapping("/hub-driver-assignment")
+    public ResponseEntity<DeliveryDriverDto.DeliveryDriverResponse> getHubDeliveryDriver() {
+        DeliveryInfo info = deliveryFacade.getHubDeliveryDriver();
+        DeliveryDriverDto.DeliveryDriverResponse response = new DeliveryDriverDto.DeliveryDriverResponse(info);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/user/src/main/java/com/springcloud/client/user/interfaces/DeliveryController.java
+++ b/user/src/main/java/com/springcloud/client/user/interfaces/DeliveryController.java
@@ -1,12 +1,11 @@
 package com.springcloud.client.user.interfaces;
 
 import com.springcloud.client.user.application.DeliveryFacade;
+import com.springcloud.client.user.domain.DeliveryCommand;
 import com.springcloud.client.user.domain.DeliveryInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -15,7 +14,15 @@ public class DeliveryController {
 
     private final DeliveryFacade deliveryFacade;
 
-    @GetMapping("/hub-driver-assignment")
+    @PostMapping("/hub-delivery-driver")
+    public ResponseEntity<DeliveryDriverDto.DeliveryDriverResponse> addHubDeliveryDriver(@RequestBody DeliveryDriverDto.DeliveryDriverRequest request) {
+        DeliveryCommand command = request.toCommand();
+        DeliveryInfo info = deliveryFacade.addHubDeliveryDriver(command);
+        DeliveryDriverDto.DeliveryDriverResponse response = new DeliveryDriverDto.DeliveryDriverResponse(info);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/hub-delivery-driver")
     public ResponseEntity<DeliveryDriverDto.DeliveryDriverResponse> getHubDeliveryDriver() {
         DeliveryInfo info = deliveryFacade.getHubDeliveryDriver();
         DeliveryDriverDto.DeliveryDriverResponse response = new DeliveryDriverDto.DeliveryDriverResponse(info);

--- a/user/src/main/java/com/springcloud/client/user/interfaces/DeliveryDriverDto.java
+++ b/user/src/main/java/com/springcloud/client/user/interfaces/DeliveryDriverDto.java
@@ -1,0 +1,25 @@
+package com.springcloud.client.user.interfaces;
+
+import com.springcloud.client.user.domain.DeliveryDriverRole;
+import com.springcloud.client.user.domain.DeliveryInfo;
+import lombok.Getter;
+
+import java.util.UUID;
+
+public class DeliveryDriverDto {
+
+    @Getter
+    public static class DeliveryDriverResponse {
+        private final UUID deliveryDriverId;
+        private final String username;
+        private final String slackId;
+        private final DeliveryDriverRole role;
+
+        public DeliveryDriverResponse(DeliveryInfo info) {
+            this.deliveryDriverId = info.getDeliveryDriverId();
+            this.username = info.getUsername();
+            this.slackId = info.getSlackId();
+            this.role = info.getRole();
+        }
+    }
+}

--- a/user/src/main/java/com/springcloud/client/user/interfaces/DeliveryDriverDto.java
+++ b/user/src/main/java/com/springcloud/client/user/interfaces/DeliveryDriverDto.java
@@ -1,5 +1,6 @@
 package com.springcloud.client.user.interfaces;
 
+import com.springcloud.client.user.domain.DeliveryCommand;
 import com.springcloud.client.user.domain.DeliveryDriverRole;
 import com.springcloud.client.user.domain.DeliveryInfo;
 import lombok.Getter;
@@ -7,6 +8,17 @@ import lombok.Getter;
 import java.util.UUID;
 
 public class DeliveryDriverDto {
+
+    @Getter
+    public static class DeliveryDriverRequest {
+        private UUID userId;
+
+        public DeliveryCommand toCommand() {
+            return DeliveryCommand.builder()
+                    .userId(this.userId)
+                    .build();
+        }
+    }
 
     @Getter
     public static class DeliveryDriverResponse {

--- a/user/src/main/resources/application.yml
+++ b/user/src/main/resources/application.yml
@@ -14,6 +14,11 @@ spring:
     password: ${Mysql_password}
 
 
+  sql:
+    init:
+      mode: always
+
+
   jpa:
     hibernate:
       ddl-auto: update

--- a/user/src/main/resources/application.yml
+++ b/user/src/main/resources/application.yml
@@ -46,6 +46,16 @@ eureka:
   client:
     service-url:
       defaultZone: http://${Eureka_name}:${Eureka_password}@${Eureka_host}:19090/eureka/
+  instance:
+    hostname: ${My_host}
+    securePortEnabled: true
+    nonSecurePortEnabled: false
+    securePort: 443
+    statusPageUrl: https://${eureka.instance.hostname}/actuator/info
+    healthCheckUrl: https://${eureka.instance.hostname}/actuator/health
+    homePageUrl: https://${eureka.instance.hostname}/
+    preferIpAddress: false
+    secureVirtualHostName: ${spring.application.name}
 
 
 jwt:

--- a/user/src/main/resources/data.sql
+++ b/user/src/main/resources/data.sql
@@ -1,0 +1,8 @@
+-- ALTER TABLE p_delivery_assignment MODIFY delivery_assignment_id VARCHAR(36);
+-- INSERT INTO p_delivery_assignment (delivery_assignment_id, current_driver_index)
+-- SELECT UUID(), 0
+-- WHERE NOT EXISTS (SELECT * FROM p_delivery_assignment);
+
+INSERT INTO p_delivery_assignment (current_driver_index)
+SELECT 0
+WHERE NOT EXISTS (SELECT * FROM p_delivery_assignment);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
#35 이슈 사항입니다.

-[x] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/#35_hub-delivery-driver -> develop

### 변경 사항
- 허브 배송 담당자 지정 기능 구현
  - 라운드로빈 방식으로 순차적 지정
    - 배정 인덱스가 배송 순번의 최댓값과 같으면 다음 배정 인덱스를 0으로 초기화
  - 담당자 지정 시 발생할 수 있는 동시성 이슈 제어를 위해 DB Pessimistic Lock 설정
    - SELECT ... FOR UPDATE를 사용하여 동일한 배송 담당자를 중복으로 배정하는 것을 방지
    - 다른 트랜잭션에서 접근할 수 없도록 하고, 현재 트랜잭션 완료 시 Lock 해제
- 다음 배송 담당자 지정을 위한 배정 인덱스 관리 테이블 추가
  - 해당 테이블의 Row에 Lock 설정
- 허브 배송 기사 추가 기능 구현
  - 배송 순번은 순번 값 중 가장 큰 값 + 1 또는 값이 없을 경우 0으로 초기화
- 허브 배송 기사 삭제 기능 구현