### PR TITLE
User_도메인별 ID 중앙 관리 기능 구현

### DIFF
--- a/user/build.gradle
+++ b/user/build.gradle
@@ -28,6 +28,8 @@ ext {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
@@ -39,6 +41,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/user/src/main/java/com/springcloud/client/user/application/IdentityIntegrationFacade.java
+++ b/user/src/main/java/com/springcloud/client/user/application/IdentityIntegrationFacade.java
@@ -1,0 +1,17 @@
+package com.springcloud.client.user.application;
+
+import com.springcloud.client.user.domain.IdentityIntegrationService;
+import com.springcloud.client.user.infrastructure.IdentityIntegrationDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class IdentityIntegrationFacade {
+
+    private final IdentityIntegrationService identityIntegrationService;
+
+    public void addIdentity(IdentityIntegrationDto dto) {
+        identityIntegrationService.addIdentity(dto);
+    }
+}

--- a/user/src/main/java/com/springcloud/client/user/application/IdentityIntegrationFacade.java
+++ b/user/src/main/java/com/springcloud/client/user/application/IdentityIntegrationFacade.java
@@ -1,7 +1,7 @@
 package com.springcloud.client.user.application;
 
+import com.springcloud.client.user.domain.IdentityIntegrationCommand;
 import com.springcloud.client.user.domain.IdentityIntegrationService;
-import com.springcloud.client.user.infrastructure.IdentityIntegrationDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,7 +11,7 @@ public class IdentityIntegrationFacade {
 
     private final IdentityIntegrationService identityIntegrationService;
 
-    public void addIdentity(IdentityIntegrationDto dto) {
-        identityIntegrationService.addIdentity(dto);
+    public void manageIdentity(IdentityIntegrationCommand command) {
+        identityIntegrationService.manageIdentity(command);
     }
 }

--- a/user/src/main/java/com/springcloud/client/user/config/ConsumerApplicationKafkaConfig.java
+++ b/user/src/main/java/com/springcloud/client/user/config/ConsumerApplicationKafkaConfig.java
@@ -1,0 +1,58 @@
+package com.springcloud.client.user.config;
+
+import com.springcloud.client.user.infrastructure.IdentityIntegrationDto;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableKafka
+public class ConsumerApplicationKafkaConfig {
+
+    @Value("${spring.kafka.host}")
+    private String kafkaHost;
+
+    @Value("${spring.kafka.username}")
+    private String kafkaName;
+
+    @Value("${spring.kafka.password}")
+    private String kafkaPassword;
+
+    @Bean
+    public ConsumerFactory<String, IdentityIntegrationDto> consumerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaHost + ":9092");
+        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+
+        configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "com.springcloud.client.user.infrastructure");  // DTO 패키지 경로
+        configProps.put(JsonDeserializer.VALUE_DEFAULT_TYPE, "com.springcloud.client.user.infrastructure.IdentityIntegrationDto");
+
+        configProps.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_PLAINTEXT");
+        configProps.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        configProps.put(SaslConfigs.SASL_JAAS_CONFIG,
+                "org.apache.kafka.common.security.plain.PlainLoginModule required " +
+                        "username=\"" + kafkaName + "\" password=\"" + kafkaPassword + "\";");
+
+        return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(), new JsonDeserializer<>(IdentityIntegrationDto.class));
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, IdentityIntegrationDto> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, IdentityIntegrationDto> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/user/src/main/java/com/springcloud/client/user/config/ConsumerApplicationKafkaConfig.java
+++ b/user/src/main/java/com/springcloud/client/user/config/ConsumerApplicationKafkaConfig.java
@@ -1,6 +1,6 @@
 package com.springcloud.client.user.config;
 
-import com.springcloud.client.user.infrastructure.IdentityIntegrationDto;
+import com.springcloud.client.user.infrastructure.IdentityIntegrationMessage;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.config.SaslConfigs;
@@ -31,14 +31,14 @@ public class ConsumerApplicationKafkaConfig {
     private String kafkaPassword;
 
     @Bean
-    public ConsumerFactory<String, IdentityIntegrationDto> consumerFactory() {
+    public ConsumerFactory<String, IdentityIntegrationMessage> consumerFactory() {
         Map<String, Object> configProps = new HashMap<>();
         configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaHost + ":9092");
         configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
 
-        configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "com.springcloud.client.user.infrastructure");  // DTO 패키지 경로
-        configProps.put(JsonDeserializer.VALUE_DEFAULT_TYPE, "com.springcloud.client.user.infrastructure.IdentityIntegrationDto");
+        configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "com.springcloud.client.user.infrastructure");
+        configProps.put(JsonDeserializer.VALUE_DEFAULT_TYPE, "com.springcloud.client.user.infrastructure.IdentityIntegrationMessage");
 
         configProps.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_PLAINTEXT");
         configProps.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
@@ -46,12 +46,12 @@ public class ConsumerApplicationKafkaConfig {
                 "org.apache.kafka.common.security.plain.PlainLoginModule required " +
                         "username=\"" + kafkaName + "\" password=\"" + kafkaPassword + "\";");
 
-        return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(), new JsonDeserializer<>(IdentityIntegrationDto.class));
+        return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(), new JsonDeserializer<>(IdentityIntegrationMessage.class));
     }
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, IdentityIntegrationDto> kafkaListenerContainerFactory() {
-        ConcurrentKafkaListenerContainerFactory<String, IdentityIntegrationDto> factory = new ConcurrentKafkaListenerContainerFactory<>();
+    public ConcurrentKafkaListenerContainerFactory<String, IdentityIntegrationMessage> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, IdentityIntegrationMessage> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
         return factory;
     }

--- a/user/src/main/java/com/springcloud/client/user/config/ProducerApplicationKafkaConfig.java
+++ b/user/src/main/java/com/springcloud/client/user/config/ProducerApplicationKafkaConfig.java
@@ -1,0 +1,50 @@
+package com.springcloud.client.user.config;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class ProducerApplicationKafkaConfig {
+
+    @Value("${spring.kafka.host}")
+    private String kafkaHost;
+
+    @Value("${spring.kafka.username}")
+    private String kafkaName;
+
+    @Value("${spring.kafka.password}")
+    private String kafkaPassword;
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaHost + ":9092");
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_PLAINTEXT");
+
+        configProps.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        configProps.put(SaslConfigs.SASL_JAAS_CONFIG,
+                "org.apache.kafka.common.security.plain.PlainLoginModule required " +
+                        "username=\"" + kafkaName + "\" password=\"" + kafkaPassword + "\";");
+
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}
+

--- a/user/src/main/java/com/springcloud/client/user/config/ProducerApplicationKafkaConfig.java
+++ b/user/src/main/java/com/springcloud/client/user/config/ProducerApplicationKafkaConfig.java
@@ -32,8 +32,8 @@ public class ProducerApplicationKafkaConfig {
         configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaHost + ":9092");
         configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-        configProps.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_PLAINTEXT");
 
+        configProps.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_PLAINTEXT");
         configProps.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
         configProps.put(SaslConfigs.SASL_JAAS_CONFIG,
                 "org.apache.kafka.common.security.plain.PlainLoginModule required " +

--- a/user/src/main/java/com/springcloud/client/user/config/RedisConfig.java
+++ b/user/src/main/java/com/springcloud/client/user/config/RedisConfig.java
@@ -1,7 +1,7 @@
 package com.springcloud.client.user.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.springcloud.client.user.infrastructure.IdentityIntegrationDto;
+import com.springcloud.client.user.domain.IdentityIntegrationCacheData;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -35,36 +35,16 @@ public class RedisConfig {
         return new LettuceConnectionFactory(config);
     }
 
-//    @Bean
-//    public RedisTemplate<String, IdentityIntegrationDto> redisTemplate(RedisConnectionFactory connectionFactory) {
-//        RedisTemplate<String, IdentityIntegrationDto> template = new RedisTemplate<>();
-//        template.setConnectionFactory(connectionFactory);
-//
-//        // JSON 직렬화 설정
-//        Jackson2JsonRedisSerializer<IdentityIntegrationDto> serializer = new Jackson2JsonRedisSerializer<>(IdentityIntegrationDto.class);
-//        ObjectMapper objectMapper = new ObjectMapper();
-//        objectMapper.registerModule(new JavaTimeModule());
-//        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-//        serializer.setObjectMapper(objectMapper);
-//
-//        // Key는 String, Value는 JSON 직렬화
-//        template.setKeySerializer(new StringRedisSerializer());
-//        template.setValueSerializer(serializer);
-//
-//        template.afterPropertiesSet();
-//        return template;
-//    }
-
     @Bean
-    public RedisTemplate<String, IdentityIntegrationDto> redisTemplate() {
-        RedisTemplate<String, IdentityIntegrationDto> template = new RedisTemplate<>();
+    public RedisTemplate<String, IdentityIntegrationCacheData> redisTemplate() {
+        RedisTemplate<String, IdentityIntegrationCacheData> template = new RedisTemplate<>();
         template.setConnectionFactory(redisConnectionFactory());
 
         template.setKeySerializer(RedisSerializer.string());
         template.setHashKeySerializer(RedisSerializer.string());
 //        template.setHashValueSerializer(RedisSerializer.json());
         ObjectMapper objectMapper = new ObjectMapper();
-        Jackson2JsonRedisSerializer<IdentityIntegrationDto> serializer = new Jackson2JsonRedisSerializer<>(IdentityIntegrationDto.class);
+        Jackson2JsonRedisSerializer<IdentityIntegrationCacheData> serializer = new Jackson2JsonRedisSerializer<>(IdentityIntegrationCacheData.class);
 
         template.setHashValueSerializer(serializer);
 

--- a/user/src/main/java/com/springcloud/client/user/config/RedisConfig.java
+++ b/user/src/main/java/com/springcloud/client/user/config/RedisConfig.java
@@ -1,0 +1,73 @@
+package com.springcloud.client.user.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.springcloud.client.user.infrastructure.IdentityIntegrationDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.username}")
+    private String username;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        config.setUsername(username);
+        config.setPassword(password);
+        return new LettuceConnectionFactory(config);
+    }
+
+//    @Bean
+//    public RedisTemplate<String, IdentityIntegrationDto> redisTemplate(RedisConnectionFactory connectionFactory) {
+//        RedisTemplate<String, IdentityIntegrationDto> template = new RedisTemplate<>();
+//        template.setConnectionFactory(connectionFactory);
+//
+//        // JSON 직렬화 설정
+//        Jackson2JsonRedisSerializer<IdentityIntegrationDto> serializer = new Jackson2JsonRedisSerializer<>(IdentityIntegrationDto.class);
+//        ObjectMapper objectMapper = new ObjectMapper();
+//        objectMapper.registerModule(new JavaTimeModule());
+//        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+//        serializer.setObjectMapper(objectMapper);
+//
+//        // Key는 String, Value는 JSON 직렬화
+//        template.setKeySerializer(new StringRedisSerializer());
+//        template.setValueSerializer(serializer);
+//
+//        template.afterPropertiesSet();
+//        return template;
+//    }
+
+    @Bean
+    public RedisTemplate<String, IdentityIntegrationDto> redisTemplate() {
+        RedisTemplate<String, IdentityIntegrationDto> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+
+        template.setKeySerializer(RedisSerializer.string());
+        template.setHashKeySerializer(RedisSerializer.string());
+//        template.setHashValueSerializer(RedisSerializer.json());
+        ObjectMapper objectMapper = new ObjectMapper();
+        Jackson2JsonRedisSerializer<IdentityIntegrationDto> serializer = new Jackson2JsonRedisSerializer<>(IdentityIntegrationDto.class);
+
+        template.setHashValueSerializer(serializer);
+
+        return template;
+    }
+}

--- a/user/src/main/java/com/springcloud/client/user/domain/DeliveryDriverRole.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/DeliveryDriverRole.java
@@ -1,5 +1,8 @@
 package com.springcloud.client.user.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum DeliveryDriverRole {
 
     HUB(DeliveryDriverRole.Authority.HUB),

--- a/user/src/main/java/com/springcloud/client/user/domain/IdentityIntegrationCacheData.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/IdentityIntegrationCacheData.java
@@ -1,0 +1,21 @@
+package com.springcloud.client.user.domain;
+
+import lombok.*;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.UUID;
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class IdentityIntegrationCacheData implements Serializable {
+
+    private UUID userId;
+    private List<UUID> orderIdList;
+    private UUID hubId;
+    private UUID companyId;
+    private UUID deliveryId;
+}

--- a/user/src/main/java/com/springcloud/client/user/domain/IdentityIntegrationCommand.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/IdentityIntegrationCommand.java
@@ -3,15 +3,28 @@ package com.springcloud.client.user.domain;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
 import java.util.UUID;
 
 @Builder
 @Getter
 public class IdentityIntegrationCommand {
 
+    private String domain;
+    private String eventType;
     private UUID userId;
+    private List<UUID> orderIdList;
     private UUID hubId;
     private UUID companyId;
-    private UUID orderId;
     private UUID deliveryId;
+
+    public IdentityIntegrationCacheData toCacheData() {
+        return IdentityIntegrationCacheData.builder()
+                .userId(this.userId)
+                .hubId(this.hubId)
+                .companyId(this.companyId)
+                .orderIdList(this.orderIdList)
+                .deliveryId(this.deliveryId)
+                .build();
+    }
 }

--- a/user/src/main/java/com/springcloud/client/user/domain/IdentityIntegrationCommand.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/IdentityIntegrationCommand.java
@@ -1,0 +1,17 @@
+package com.springcloud.client.user.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Builder
+@Getter
+public class IdentityIntegrationCommand {
+
+    private UUID userId;
+    private UUID hubId;
+    private UUID companyId;
+    private UUID orderId;
+    private UUID deliveryId;
+}

--- a/user/src/main/java/com/springcloud/client/user/domain/IdentityIntegrationService.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/IdentityIntegrationService.java
@@ -1,36 +1,76 @@
 package com.springcloud.client.user.domain;
 
-import com.springcloud.client.user.infrastructure.IdentityIntegrationDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
-import java.util.concurrent.TimeUnit;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
 public class IdentityIntegrationService {
 
-    private final RedisTemplate<String, IdentityIntegrationDto> redisTemplate;
     private static final String HASH_TABLE_KEY = "identityIntegrationCache";
+    private final RedisTemplate<String, IdentityIntegrationCacheData> redisTemplate;
 
-    public void addIdentity(IdentityIntegrationDto dto) {
-        String fieldKey = dto.getUserId().toString();
+    public void manageIdentity(IdentityIntegrationCommand command) {
+        String fieldKey = command.getUserId().toString();
 
-        // Redis에 기존 데이터가 있는지 확인
-        IdentityIntegrationDto existingData = (IdentityIntegrationDto) redisTemplate.opsForHash().get("identityIntegrationCache", fieldKey);
-
-        if (existingData != null) {
-            // 기존 데이터가 있으면 업데이트
-            if (dto.getHubId() != null) existingData.setHubId(dto.getHubId());
-            if (dto.getCompanyId() != null) existingData.setCompanyId(dto.getCompanyId());
-            if (dto.getOrderId() != null) existingData.setOrderId(dto.getOrderId());
-            if (dto.getDeliveryId() != null) existingData.setDeliveryId(dto.getDeliveryId());
-
-            redisTemplate.opsForValue().set(fieldKey, existingData, 3, TimeUnit.DAYS);
-        } else {
-            // 없으면 새로 저장
-            redisTemplate.opsForHash().put(HASH_TABLE_KEY, fieldKey, dto);
+        if (command.getEventType().equals("CREATE")) {
+            createIdentity(command, fieldKey);
         }
+        if (command.getEventType().equals("UPDATE")) {
+            updateIdentity(command, fieldKey);
+        }
+        if (command.getEventType().equals("DELETE")) {
+            deleteIdentity(command, fieldKey);
+        }
+    }
+
+    private void createIdentity(IdentityIntegrationCommand command, String fieldKey) {
+        IdentityIntegrationCacheData identityIntegrationCacheData = command.toCacheData();
+        redisTemplate.opsForHash().put(HASH_TABLE_KEY, fieldKey, identityIntegrationCacheData);
+    }
+
+    private void updateIdentity(IdentityIntegrationCommand command, String fieldKey) {
+        IdentityIntegrationCacheData existingData = (IdentityIntegrationCacheData) redisTemplate.opsForHash().get(HASH_TABLE_KEY, fieldKey);
+
+        if (command.getHubId() != null) {
+            existingData.setHubId(command.getHubId());
+        }
+        if (command.getCompanyId() != null) {
+            existingData.setCompanyId(command.getCompanyId());
+        }
+        if (command.getDeliveryId() != null) {
+            existingData.setDeliveryId(command.getDeliveryId());
+        }
+        if (command.getOrderIdList() != null) {
+            List<UUID> orderIdList = existingData.getOrderIdList();
+            orderIdList.addAll(command.getOrderIdList());
+            existingData.setOrderIdList(orderIdList);
+        }
+
+        redisTemplate.opsForHash().put(HASH_TABLE_KEY, fieldKey, existingData);
+    }
+
+    private void deleteIdentity(IdentityIntegrationCommand command, String fieldKey) {
+        IdentityIntegrationCacheData existingData = (IdentityIntegrationCacheData) redisTemplate.opsForHash().get(HASH_TABLE_KEY, fieldKey);
+
+        if (command.getDomain().equals("COMPANY")) {
+            existingData.setCompanyId(null);
+        }
+        if (command.getDomain().equals("HUB")) {
+            existingData.setHubId(null);
+        }
+        if (command.getDomain().equals("DELIVERY")) {
+            existingData.setDeliveryId(null);
+        }
+        if (command.getDomain().equals("ORDER")) {
+            List<UUID> orderIdList = existingData.getOrderIdList();
+            orderIdList.removeAll(command.getOrderIdList());
+            existingData.setOrderIdList(orderIdList);
+        }
+
+        redisTemplate.opsForHash().put(HASH_TABLE_KEY, fieldKey, existingData);
     }
 }

--- a/user/src/main/java/com/springcloud/client/user/domain/IdentityIntegrationService.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/IdentityIntegrationService.java
@@ -1,0 +1,36 @@
+package com.springcloud.client.user.domain;
+
+import com.springcloud.client.user.infrastructure.IdentityIntegrationDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class IdentityIntegrationService {
+
+    private final RedisTemplate<String, IdentityIntegrationDto> redisTemplate;
+    private static final String KEY_PREFIX = "identityIntegrationCache:";
+
+    public void addIdentity(IdentityIntegrationDto dto) {
+        String key = KEY_PREFIX + dto.getUserId().toString();
+
+        // Redis에 기존 데이터가 있는지 확인
+        IdentityIntegrationDto existingData = (IdentityIntegrationDto) redisTemplate.opsForHash().get("identityIntegrationCache", key);
+
+        if (existingData != null) {
+            // 기존 데이터가 있으면 업데이트
+            if (dto.getHubId() != null) existingData.setHubId(dto.getHubId());
+            if (dto.getCompanyId() != null) existingData.setCompanyId(dto.getCompanyId());
+            if (dto.getOrderId() != null) existingData.setOrderId(dto.getOrderId());
+            if (dto.getDeliveryId() != null) existingData.setDeliveryId(dto.getDeliveryId());
+
+            redisTemplate.opsForValue().set(key, existingData, 3, TimeUnit.DAYS);
+        } else {
+            // 없으면 새로 저장
+            redisTemplate.opsForHash().put("identityIntegrationCache", key, dto);
+        }
+    }
+}

--- a/user/src/main/java/com/springcloud/client/user/domain/IdentityIntegrationService.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/IdentityIntegrationService.java
@@ -18,11 +18,9 @@ public class IdentityIntegrationService {
 
         if (command.getEventType().equals("CREATE")) {
             createIdentity(command, fieldKey);
-        }
-        if (command.getEventType().equals("UPDATE")) {
+        } else if (command.getEventType().equals("UPDATE")) {
             updateIdentity(command, fieldKey);
-        }
-        if (command.getEventType().equals("DELETE")) {
+        } else if (command.getEventType().equals("DELETE")) {
             deleteIdentity(command, fieldKey);
         }
     }
@@ -37,14 +35,11 @@ public class IdentityIntegrationService {
 
         if (command.getHubId() != null) {
             existingData.setHubId(command.getHubId());
-        }
-        if (command.getCompanyId() != null) {
+        } else if (command.getCompanyId() != null) {
             existingData.setCompanyId(command.getCompanyId());
-        }
-        if (command.getDeliveryId() != null) {
+        } else if (command.getDeliveryId() != null) {
             existingData.setDeliveryId(command.getDeliveryId());
-        }
-        if (command.getOrderIdList() != null) {
+        } else if (command.getOrderIdList() != null) {
             List<UUID> orderIdList = existingData.getOrderIdList();
             orderIdList.addAll(command.getOrderIdList());
             existingData.setOrderIdList(orderIdList);
@@ -58,14 +53,11 @@ public class IdentityIntegrationService {
 
         if (command.getDomain().equals("COMPANY")) {
             existingData.setCompanyId(null);
-        }
-        if (command.getDomain().equals("HUB")) {
+        } else if (command.getDomain().equals("HUB")) {
             existingData.setHubId(null);
-        }
-        if (command.getDomain().equals("DELIVERY")) {
+        } else if (command.getDomain().equals("DELIVERY")) {
             existingData.setDeliveryId(null);
-        }
-        if (command.getDomain().equals("ORDER")) {
+        } else if (command.getDomain().equals("ORDER")) {
             List<UUID> orderIdList = existingData.getOrderIdList();
             orderIdList.removeAll(command.getOrderIdList());
             existingData.setOrderIdList(orderIdList);

--- a/user/src/main/java/com/springcloud/client/user/domain/IdentityIntegrationService.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/IdentityIntegrationService.java
@@ -16,33 +16,34 @@ public class IdentityIntegrationService {
     public void manageIdentity(IdentityIntegrationCommand command) {
         String fieldKey = command.getUserId().toString();
 
-        if (command.getEventType().equals("CREATE")) {
-            createIdentity(command, fieldKey);
-        } else if (command.getEventType().equals("UPDATE")) {
-            updateIdentity(command, fieldKey);
-        } else if (command.getEventType().equals("DELETE")) {
-            deleteIdentity(command, fieldKey);
+        MessageEventType eventType = MessageEventType.valueOf(command.getEventType());
+
+        switch (eventType) {
+            case CREATE -> createIdentity(command, fieldKey);
+            case UPDATE -> updateIdentity(command, fieldKey);
+            case DELETE -> deleteIdentity(command, fieldKey);
         }
     }
 
     private void createIdentity(IdentityIntegrationCommand command, String fieldKey) {
-        IdentityIntegrationCacheData identityIntegrationCacheData = command.toCacheData();
-        redisTemplate.opsForHash().put(HASH_TABLE_KEY, fieldKey, identityIntegrationCacheData);
+        IdentityIntegrationCacheData newData = command.toCacheData();
+        redisTemplate.opsForHash().put(HASH_TABLE_KEY, fieldKey, newData);
     }
 
     private void updateIdentity(IdentityIntegrationCommand command, String fieldKey) {
         IdentityIntegrationCacheData existingData = (IdentityIntegrationCacheData) redisTemplate.opsForHash().get(HASH_TABLE_KEY, fieldKey);
 
-        if (command.getHubId() != null) {
-            existingData.setHubId(command.getHubId());
-        } else if (command.getCompanyId() != null) {
-            existingData.setCompanyId(command.getCompanyId());
-        } else if (command.getDeliveryId() != null) {
-            existingData.setDeliveryId(command.getDeliveryId());
-        } else if (command.getOrderIdList() != null) {
-            List<UUID> orderIdList = existingData.getOrderIdList();
-            orderIdList.addAll(command.getOrderIdList());
-            existingData.setOrderIdList(orderIdList);
+        MessageDomain domain = MessageDomain.valueOf(command.getDomain());
+
+        switch (domain) {
+            case COMPANY -> existingData.setCompanyId(command.getCompanyId());
+            case HUB -> existingData.setHubId(command.getHubId());
+            case DELIVERY -> existingData.setDeliveryId(command.getDeliveryId());
+            case ORDER -> {
+                List<UUID> orderIdList = existingData.getOrderIdList();
+                orderIdList.addAll(command.getOrderIdList());
+                existingData.setOrderIdList(orderIdList);
+            }
         }
 
         redisTemplate.opsForHash().put(HASH_TABLE_KEY, fieldKey, existingData);
@@ -51,16 +52,17 @@ public class IdentityIntegrationService {
     private void deleteIdentity(IdentityIntegrationCommand command, String fieldKey) {
         IdentityIntegrationCacheData existingData = (IdentityIntegrationCacheData) redisTemplate.opsForHash().get(HASH_TABLE_KEY, fieldKey);
 
-        if (command.getDomain().equals("COMPANY")) {
-            existingData.setCompanyId(null);
-        } else if (command.getDomain().equals("HUB")) {
-            existingData.setHubId(null);
-        } else if (command.getDomain().equals("DELIVERY")) {
-            existingData.setDeliveryId(null);
-        } else if (command.getDomain().equals("ORDER")) {
-            List<UUID> orderIdList = existingData.getOrderIdList();
-            orderIdList.removeAll(command.getOrderIdList());
-            existingData.setOrderIdList(orderIdList);
+        MessageDomain domain = MessageDomain.valueOf(command.getDomain());
+
+        switch (domain) {
+            case COMPANY -> existingData.setCompanyId(null);
+            case HUB -> existingData.setHubId(null);
+            case DELIVERY -> existingData.setDeliveryId(null);
+            case ORDER -> {
+                List<UUID> orderIdList = existingData.getOrderIdList();
+                orderIdList.removeAll(command.getOrderIdList());
+                existingData.setOrderIdList(orderIdList);
+            }
         }
 
         redisTemplate.opsForHash().put(HASH_TABLE_KEY, fieldKey, existingData);

--- a/user/src/main/java/com/springcloud/client/user/domain/IdentityIntegrationService.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/IdentityIntegrationService.java
@@ -12,13 +12,13 @@ import java.util.concurrent.TimeUnit;
 public class IdentityIntegrationService {
 
     private final RedisTemplate<String, IdentityIntegrationDto> redisTemplate;
-    private static final String KEY_PREFIX = "identityIntegrationCache:";
+    private static final String HASH_TABLE_KEY = "identityIntegrationCache";
 
     public void addIdentity(IdentityIntegrationDto dto) {
-        String key = KEY_PREFIX + dto.getUserId().toString();
+        String fieldKey = dto.getUserId().toString();
 
         // Redis에 기존 데이터가 있는지 확인
-        IdentityIntegrationDto existingData = (IdentityIntegrationDto) redisTemplate.opsForHash().get("identityIntegrationCache", key);
+        IdentityIntegrationDto existingData = (IdentityIntegrationDto) redisTemplate.opsForHash().get("identityIntegrationCache", fieldKey);
 
         if (existingData != null) {
             // 기존 데이터가 있으면 업데이트
@@ -27,10 +27,10 @@ public class IdentityIntegrationService {
             if (dto.getOrderId() != null) existingData.setOrderId(dto.getOrderId());
             if (dto.getDeliveryId() != null) existingData.setDeliveryId(dto.getDeliveryId());
 
-            redisTemplate.opsForValue().set(key, existingData, 3, TimeUnit.DAYS);
+            redisTemplate.opsForValue().set(fieldKey, existingData, 3, TimeUnit.DAYS);
         } else {
             // 없으면 새로 저장
-            redisTemplate.opsForHash().put("identityIntegrationCache", key, dto);
+            redisTemplate.opsForHash().put(HASH_TABLE_KEY, fieldKey, dto);
         }
     }
 }

--- a/user/src/main/java/com/springcloud/client/user/domain/MessageDomain.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/MessageDomain.java
@@ -1,0 +1,6 @@
+package com.springcloud.client.user.domain;
+
+public enum MessageDomain {
+
+    ORDER, HUB, COMPANY, DELIVERY
+}

--- a/user/src/main/java/com/springcloud/client/user/domain/MessageEventType.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/MessageEventType.java
@@ -1,0 +1,6 @@
+package com.springcloud.client.user.domain;
+
+public enum MessageEventType {
+
+    CREATE, UPDATE, DELETE
+}

--- a/user/src/main/java/com/springcloud/client/user/infrastructure/IdentityIntegrationDto.java
+++ b/user/src/main/java/com/springcloud/client/user/infrastructure/IdentityIntegrationDto.java
@@ -1,0 +1,33 @@
+package com.springcloud.client.user.infrastructure;
+
+import com.springcloud.client.user.domain.IdentityIntegrationCommand;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class IdentityIntegrationDto implements Serializable {
+
+    private UUID userId;
+    private UUID hubId;
+    private UUID companyId;
+    private UUID orderId;
+    private UUID deliveryId;
+
+    public IdentityIntegrationCommand toCommand() {
+        return IdentityIntegrationCommand.builder()
+                .userId(this.userId)
+                .hubId(this.hubId)
+                .companyId(this.companyId)
+                .orderId(this.orderId)
+                .deliveryId(this.deliveryId)
+                .build();
+    }
+}

--- a/user/src/main/java/com/springcloud/client/user/infrastructure/IdentityIntegrationMessage.java
+++ b/user/src/main/java/com/springcloud/client/user/infrastructure/IdentityIntegrationMessage.java
@@ -7,13 +7,15 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class IdentityIntegrationDto implements Serializable {
+public class IdentityIntegrationMessage implements Serializable {
 
     private UUID userId;
     private UUID hubId;
@@ -21,12 +23,14 @@ public class IdentityIntegrationDto implements Serializable {
     private UUID orderId;
     private UUID deliveryId;
 
-    public IdentityIntegrationCommand toCommand() {
+    public IdentityIntegrationCommand toCommand(String key) {
         return IdentityIntegrationCommand.builder()
+                .domain(key.split(":")[0])
+                .eventType(key.split(":")[1])
                 .userId(this.userId)
                 .hubId(this.hubId)
                 .companyId(this.companyId)
-                .orderId(this.orderId)
+                .orderIdList(this.orderId == null ? new ArrayList<>() : new ArrayList<>(List.of(this.orderId)))
                 .deliveryId(this.deliveryId)
                 .build();
     }

--- a/user/src/main/java/com/springcloud/client/user/infrastructure/KafkaMessageListener.java
+++ b/user/src/main/java/com/springcloud/client/user/infrastructure/KafkaMessageListener.java
@@ -1,6 +1,7 @@
 package com.springcloud.client.user.infrastructure;
 
 import com.springcloud.client.user.application.IdentityIntegrationFacade;
+import com.springcloud.client.user.domain.IdentityIntegrationCommand;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -14,10 +15,11 @@ public class KafkaMessageListener implements MessageListener {
 
     private final IdentityIntegrationFacade identityIntegrationFacade;
 
-    @KafkaListener(groupId = "user-group", topics = "integrated-user-topic", containerFactory = "kafkaListenerContainerFactory"
-    )
-    public void consumeMessage(ConsumerRecord<String, IdentityIntegrationDto> record) {
-        IdentityIntegrationDto dto = record.value();
-        identityIntegrationFacade.addIdentity(dto);
+    @KafkaListener(groupId = "user-group", topics = "integrated-user-topic", containerFactory = "kafkaListenerContainerFactory")
+    public void consumeMessage(ConsumerRecord<String, IdentityIntegrationMessage> record) {
+        String key = record.key();
+        IdentityIntegrationMessage message = record.value();
+        IdentityIntegrationCommand command = message.toCommand(key);
+        identityIntegrationFacade.manageIdentity(command);
     }
 }

--- a/user/src/main/java/com/springcloud/client/user/infrastructure/KafkaMessageListener.java
+++ b/user/src/main/java/com/springcloud/client/user/infrastructure/KafkaMessageListener.java
@@ -1,0 +1,23 @@
+package com.springcloud.client.user.infrastructure;
+
+import com.springcloud.client.user.application.IdentityIntegrationFacade;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KafkaMessageListener implements MessageListener {
+
+    private final IdentityIntegrationFacade identityIntegrationFacade;
+
+    @KafkaListener(groupId = "user-group", topics = "integrated-user-topic", containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void consumeMessage(ConsumerRecord<String, IdentityIntegrationDto> record) {
+        IdentityIntegrationDto dto = record.value();
+        identityIntegrationFacade.addIdentity(dto);
+    }
+}

--- a/user/src/main/java/com/springcloud/client/user/infrastructure/MessageListener.java
+++ b/user/src/main/java/com/springcloud/client/user/infrastructure/MessageListener.java
@@ -4,5 +4,5 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 
 public interface MessageListener {
 
-    void consumeMessage(ConsumerRecord<String, IdentityIntegrationDto> record);
+    void consumeMessage(ConsumerRecord<String, IdentityIntegrationMessage> record);
 }

--- a/user/src/main/java/com/springcloud/client/user/infrastructure/MessageListener.java
+++ b/user/src/main/java/com/springcloud/client/user/infrastructure/MessageListener.java
@@ -1,0 +1,8 @@
+package com.springcloud.client.user.infrastructure;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+public interface MessageListener {
+
+    void consumeMessage(ConsumerRecord<String, IdentityIntegrationDto> record);
+}

--- a/user/src/main/java/com/springcloud/client/user/interfaces/IdentityIntegrationDto.java
+++ b/user/src/main/java/com/springcloud/client/user/interfaces/IdentityIntegrationDto.java
@@ -7,6 +7,8 @@ import java.util.UUID;
 @Getter
 public class IdentityIntegrationDto {
 
+    private String domain;
+    private String eventType;
     private UUID userId;
     private UUID hubId;
     private UUID companyId;

--- a/user/src/main/java/com/springcloud/client/user/interfaces/IdentityIntegrationDto.java
+++ b/user/src/main/java/com/springcloud/client/user/interfaces/IdentityIntegrationDto.java
@@ -1,0 +1,15 @@
+package com.springcloud.client.user.interfaces;
+
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class IdentityIntegrationDto {
+
+    private UUID userId;
+    private UUID hubId;
+    private UUID companyId;
+    private UUID orderId;
+    private UUID deliveryId;
+}

--- a/user/src/main/java/com/springcloud/client/user/interfaces/KafkaController.java
+++ b/user/src/main/java/com/springcloud/client/user/interfaces/KafkaController.java
@@ -19,8 +19,10 @@ public class KafkaController {
         // DTO -> JSON 변환
         String jsonMessage = objectMapper.writeValueAsString(request);
 
+        String key = request.getDomain() + ":" + request.getEventType();
+
         // Kafka 전송
-        kafkaTemplate.send(topic, "COMPANY:CREATE", jsonMessage);
+        kafkaTemplate.send(topic, key, jsonMessage);
 
         return "Message sent to Kafka topic";
     }

--- a/user/src/main/java/com/springcloud/client/user/interfaces/KafkaController.java
+++ b/user/src/main/java/com/springcloud/client/user/interfaces/KafkaController.java
@@ -1,0 +1,27 @@
+package com.springcloud.client.user.interfaces;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/kafka")
+public class KafkaController {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @PostMapping("/send/test")
+    public String sendMessage(@RequestParam("topic") String topic, @RequestBody IdentityIntegrationDto request) throws JsonProcessingException {
+        // DTO -> JSON 변환
+        String jsonMessage = objectMapper.writeValueAsString(request);
+
+        // Kafka 전송
+        kafkaTemplate.send(topic, "COMPANY:CREATE", jsonMessage);
+
+        return "Message sent to Kafka topic";
+    }
+}

--- a/user/src/main/resources/application.yml
+++ b/user/src/main/resources/application.yml
@@ -36,10 +36,15 @@ spring:
       username: ${Redis_name}
       password: ${Redis_password}
 
+
   kafka:
     host: ${Kafka_host}
+    bootstrap-servers: ${Kafka_host}:9092
     username: ${Kafka_name}
     password: ${Kafka_password}
+    consumer:
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
 
 
 eureka:


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[x] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/#61_central-id-management -> develop

### 변경 사항
- 카프카 메시지 리스너 구현
- 레디스 해시 테이블에 ID 저장 기능 구현
  - 이벤트 타입 'CREATE', 'UPDATE', 'DELETE'에 따른 처리 로직 구현