### PR TITLE
User_업체 배송 담당자 지정/추가/삭제 기능 구현

### DIFF
--- a/user/src/main/java/com/springcloud/client/user/application/DeliveryFacade.java
+++ b/user/src/main/java/com/springcloud/client/user/application/DeliveryFacade.java
@@ -6,6 +6,8 @@ import com.springcloud.client.user.domain.DeliveryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 public class DeliveryFacade {
@@ -20,7 +22,15 @@ public class DeliveryFacade {
         return deliveryService.getHubDeliveryDriver();
     }
 
-    public void deleteHubDeliveryDriver(DeliveryCommand command) {
-        deliveryService.deleteHubDeliveryDriver(command);
+    public DeliveryInfo addCompanyDeliveryDriver(DeliveryCommand command) {
+        return deliveryService.addCompanyDeliveryDriver(command);
+    }
+
+    public DeliveryInfo getCompanyDeliveryDriver(UUID hubId) {
+        return deliveryService.getCompanyDeliveryDriver(hubId);
+    }
+
+    public void deleteDeliveryDriver(DeliveryCommand command) {
+        deliveryService.deleteDeliveryDriver(command);
     }
 }

--- a/user/src/main/java/com/springcloud/client/user/domain/DeliveryAssignment.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/DeliveryAssignment.java
@@ -12,11 +12,16 @@ public class DeliveryAssignment {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Comment("PK")
-    private Integer deliveryAssignmentId;
+    private Byte deliveryAssignmentId;
 
     @Column(nullable = false)
     @Comment("현재 배송 담당자 인덱스")
-    private int currentDriverIndex;
+    private Integer currentDriverIndex;
+
+    @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    @Comment("배송 기사 역할 (허브 or 업체)")
+    private DeliveryDriverRole driverType;
 
     public void updateCurrentDriverIndex(int newIndex) {
         this.currentDriverIndex = newIndex;

--- a/user/src/main/java/com/springcloud/client/user/domain/DeliveryCommand.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/DeliveryCommand.java
@@ -10,12 +10,14 @@ import java.util.UUID;
 public class DeliveryCommand {
 
     private UUID userId;
+    private UUID hubId;
 
     public DeliveryDriver toEntity(User user, int deliveryOrderNumber) {
         return DeliveryDriver.builder()
                 .user(user)
+                .hubId(this.hubId)
                 .deliveryOrderNumber(deliveryOrderNumber)
-                .role(DeliveryDriverRole.HUB)
+                .role(hubId == null ? DeliveryDriverRole.HUB : DeliveryDriverRole.COMPANY)
                 .build();
     }
 }

--- a/user/src/main/java/com/springcloud/client/user/domain/DeliveryDriver.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/DeliveryDriver.java
@@ -36,6 +36,6 @@ public class DeliveryDriver extends BaseEntity {
 
     @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)
-    @Comment("배송 기사 권한")
+    @Comment("배송 기사 역할 (허브 or 업체)")
     private DeliveryDriverRole role;
 }

--- a/user/src/main/java/com/springcloud/client/user/domain/DeliveryInfo.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/DeliveryInfo.java
@@ -7,15 +7,19 @@ import java.util.UUID;
 @Getter
 public class DeliveryInfo {
 
+    private final UUID userId;
     private final UUID deliveryDriverId;
     private final String username;
     private final String slackId;
     private final DeliveryDriverRole role;
+    private final UUID hubId;
 
     public DeliveryInfo(DeliveryDriver deliveryDriver) {
+        this.userId = deliveryDriver.getUser().getUserId();
         this.deliveryDriverId = deliveryDriver.getDeliveryDriverId();
         this.username = deliveryDriver.getUser().getUsername();
         this.slackId = deliveryDriver.getUser().getSlackId();
         this.role = deliveryDriver.getRole();
+        this.hubId = deliveryDriver.getHubId();
     }
 }

--- a/user/src/main/java/com/springcloud/client/user/domain/DeliveryReader.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/DeliveryReader.java
@@ -10,7 +10,9 @@ public interface DeliveryReader {
 
     List<DeliveryDriver> findAllByRoleOrderByDeliveryOrderNumberAsc(DeliveryDriverRole role);
 
-    DeliveryAssignment findWithLock(int pk);
+    DeliveryAssignment findWithLock(DeliveryDriverRole driverType);
 
     Optional<DeliveryDriver> findById(UUID userId);
+
+    List<DeliveryDriver> findAllByHubIdAndRoleOrderByDeliveryOrderNumberAsc(UUID hubId, DeliveryDriverRole role);
 }

--- a/user/src/main/java/com/springcloud/client/user/domain/DeliveryService.java
+++ b/user/src/main/java/com/springcloud/client/user/domain/DeliveryService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -13,7 +14,8 @@ public class DeliveryService {
     private final DeliveryReader deliveryReader;
     private final DeliveryStore deliveryStore;
     private final UserReader userReader;
-    private static final int PK_FOR_HUB_DELIVERY_DRIVER_INDEX = 1;
+    private static final DeliveryDriverRole CURRENT_DRIVER_INDEX_FOR_HUB = DeliveryDriverRole.HUB;
+    private static final DeliveryDriverRole CURRENT_DRIVER_INDEX_FOR_COMPANY = DeliveryDriverRole.COMPANY;
 
     @Transactional
     public DeliveryInfo addHubDeliveryDriver(DeliveryCommand command) {
@@ -37,7 +39,7 @@ public class DeliveryService {
             throw new IllegalStateException("등록된 허브 배송 담당자가 없습니다.");
         }
 
-        DeliveryAssignment assignment = deliveryReader.findWithLock(PK_FOR_HUB_DELIVERY_DRIVER_INDEX);
+        DeliveryAssignment assignment = deliveryReader.findWithLock(CURRENT_DRIVER_INDEX_FOR_HUB);
 
         DeliveryDriver deliveryDriver = drivers.get(assignment.getCurrentDriverIndex());
 
@@ -48,7 +50,38 @@ public class DeliveryService {
         return new DeliveryInfo(deliveryDriver);
     }
 
-    public void deleteHubDeliveryDriver(DeliveryCommand command) {
+    public DeliveryInfo addCompanyDeliveryDriver(DeliveryCommand command) {
+        User user = userReader.findById(command.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        Integer maxOrderNumber = deliveryReader.findMaxDeliveryOrderNumberByRole(DeliveryDriverRole.COMPANY);
+        int newOrderNumber = (maxOrderNumber == null) ? 0 : maxOrderNumber + 1;
+
+        DeliveryDriver deliveryDriver = command.toEntity(user, newOrderNumber);
+
+        DeliveryDriver savedDriver = deliveryStore.save(deliveryDriver);
+        return new DeliveryInfo(savedDriver);
+    }
+
+    @Transactional
+    public DeliveryInfo getCompanyDeliveryDriver(UUID hubId) {
+        List<DeliveryDriver> drivers = deliveryReader.findAllByHubIdAndRoleOrderByDeliveryOrderNumberAsc(hubId, DeliveryDriverRole.COMPANY);
+        if (drivers.isEmpty()) {
+            throw new IllegalStateException("해당 허브에 등록된 업체 배송 담당자가 없습니다.");
+        }
+
+        DeliveryAssignment assignment = deliveryReader.findWithLock(CURRENT_DRIVER_INDEX_FOR_COMPANY);
+
+        DeliveryDriver deliveryDriver = drivers.get(assignment.getCurrentDriverIndex());
+
+        int nextDriverIndex = (assignment.getCurrentDriverIndex() + 1) % drivers.size();
+        assignment.updateCurrentDriverIndex(nextDriverIndex);
+        deliveryStore.save(assignment);
+
+        return new DeliveryInfo(deliveryDriver);
+    }
+
+    public void deleteDeliveryDriver(DeliveryCommand command) {
         DeliveryDriver deliveryDriver = deliveryReader.findById(command.getUserId())
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 

--- a/user/src/main/java/com/springcloud/client/user/infrastructure/DeliveryAssignmentRepository.java
+++ b/user/src/main/java/com/springcloud/client/user/infrastructure/DeliveryAssignmentRepository.java
@@ -1,15 +1,15 @@
 package com.springcloud.client.user.infrastructure;
 
 import com.springcloud.client.user.domain.DeliveryAssignment;
+import com.springcloud.client.user.domain.DeliveryDriverRole;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface DeliveryAssignmentRepository extends JpaRepository<DeliveryAssignment, Integer> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT da FROM DeliveryAssignment da WHERE da.deliveryAssignmentId = :id")
-    DeliveryAssignment findWithLock(@Param("id") Integer id);
+    @Query("SELECT da FROM DeliveryAssignment da WHERE da.driverType = :driverType")
+    DeliveryAssignment findWithLock(DeliveryDriverRole driverType);
 }

--- a/user/src/main/java/com/springcloud/client/user/infrastructure/DeliveryReaderImpl.java
+++ b/user/src/main/java/com/springcloud/client/user/infrastructure/DeliveryReaderImpl.java
@@ -29,12 +29,17 @@ public class DeliveryReaderImpl implements DeliveryReader {
     }
 
     @Override
-    public DeliveryAssignment findWithLock(int pk) {
-        return deliveryAssignmentRepository.findWithLock(pk);
+    public DeliveryAssignment findWithLock(DeliveryDriverRole driverType) {
+        return deliveryAssignmentRepository.findWithLock(driverType);
     }
 
     @Override
     public Optional<DeliveryDriver> findById(UUID userId) {
         return deliveryRepository.findById(userId);
+    }
+
+    @Override
+    public List<DeliveryDriver> findAllByHubIdAndRoleOrderByDeliveryOrderNumberAsc(UUID hubId, DeliveryDriverRole role) {
+        return deliveryRepository.findAllByHubIdAndRoleOrderByDeliveryOrderNumberAsc(hubId, role);
     }
 }

--- a/user/src/main/java/com/springcloud/client/user/infrastructure/DeliveryRepository.java
+++ b/user/src/main/java/com/springcloud/client/user/infrastructure/DeliveryRepository.java
@@ -17,4 +17,6 @@ public interface DeliveryRepository extends JpaRepository<DeliveryDriver, UUID> 
 
     // Role이 HUB인 배송 기사들을 deliveryOrderNumber 순으로 조회
     List<DeliveryDriver> findAllByRoleOrderByDeliveryOrderNumberAsc(DeliveryDriverRole role);
+
+    List<DeliveryDriver> findAllByHubIdAndRoleOrderByDeliveryOrderNumberAsc(UUID hubId, DeliveryDriverRole role);
 }

--- a/user/src/main/java/com/springcloud/client/user/interfaces/DeliveryController.java
+++ b/user/src/main/java/com/springcloud/client/user/interfaces/DeliveryController.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.UUID;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/users")
@@ -29,10 +31,26 @@ public class DeliveryController {
         return ResponseEntity.ok(response);
     }
 
-    @PatchMapping("/hub-delivery-driver")
-    public ResponseEntity<Void> deleteHubDeliveryDriver(@RequestBody DeliveryDriverDto.DeliveryDriverRequest request) {
+
+    @PostMapping("/company-delivery-driver")
+    public ResponseEntity<DeliveryDriverDto.DeliveryDriverResponse> addCompanyDeliveryDriver(@RequestBody DeliveryDriverDto.DeliveryDriverRequest request) {
         DeliveryCommand command = request.toCommand();
-        deliveryFacade.deleteHubDeliveryDriver(command);
+        DeliveryInfo info = deliveryFacade.addCompanyDeliveryDriver(command);
+        DeliveryDriverDto.DeliveryDriverResponse response = new DeliveryDriverDto.DeliveryDriverResponse(info);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/company-delivery-driver/{hubId}")
+    public ResponseEntity<DeliveryDriverDto.DeliveryDriverResponse> getCompanyDeliveryDriver(@PathVariable UUID hubId) {
+        DeliveryInfo info = deliveryFacade.getCompanyDeliveryDriver(hubId);
+        DeliveryDriverDto.DeliveryDriverResponse response = new DeliveryDriverDto.DeliveryDriverResponse(info);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/delivery-driver/delete")
+    public ResponseEntity<Void> deleteDeliveryDriver(@RequestBody DeliveryDriverDto.DeliveryDriverRequest request) {
+        DeliveryCommand command = request.toCommand();
+        deliveryFacade.deleteDeliveryDriver(command);
         return ResponseEntity.noContent().build();
     }
 }

--- a/user/src/main/java/com/springcloud/client/user/interfaces/DeliveryDriverDto.java
+++ b/user/src/main/java/com/springcloud/client/user/interfaces/DeliveryDriverDto.java
@@ -12,26 +12,32 @@ public class DeliveryDriverDto {
     @Getter
     public static class DeliveryDriverRequest {
         private UUID userId;
+        private UUID hubId;
 
         public DeliveryCommand toCommand() {
             return DeliveryCommand.builder()
                     .userId(this.userId)
+                    .hubId(this.hubId)
                     .build();
         }
     }
 
     @Getter
     public static class DeliveryDriverResponse {
+        private final UUID userId;
         private final UUID deliveryDriverId;
         private final String username;
         private final String slackId;
         private final DeliveryDriverRole role;
+        private final UUID hubId;
 
         public DeliveryDriverResponse(DeliveryInfo info) {
+            this.userId = info.getUserId();
             this.deliveryDriverId = info.getDeliveryDriverId();
             this.username = info.getUsername();
             this.slackId = info.getSlackId();
             this.role = info.getRole();
+            this.hubId = info.getHubId();
         }
     }
 }

--- a/user/src/main/resources/data.sql
+++ b/user/src/main/resources/data.sql
@@ -1,8 +1,13 @@
--- ALTER TABLE p_delivery_assignment MODIFY delivery_assignment_id VARCHAR(36);
--- INSERT INTO p_delivery_assignment (delivery_assignment_id, current_driver_index)
--- SELECT UUID(), 0
--- WHERE NOT EXISTS (SELECT * FROM p_delivery_assignment);
+CREATE TABLE IF NOT EXISTS p_delivery_assignment (
+    delivery_assignment_id TINYINT AUTO_INCREMENT PRIMARY KEY,
+    current_driver_index INT NOT NULL,
+    driver_type VARCHAR(20) NOT NULL
+);
 
-INSERT INTO p_delivery_assignment (current_driver_index)
-SELECT 0
-WHERE NOT EXISTS (SELECT * FROM p_delivery_assignment);
+INSERT INTO p_delivery_assignment (current_driver_index, driver_type)
+SELECT 0, 'HUB'
+WHERE NOT EXISTS (SELECT * FROM p_delivery_assignment WHERE driver_type = 'HUB');
+
+INSERT INTO p_delivery_assignment (current_driver_index, driver_type)
+SELECT 0, 'COMPANY'
+WHERE NOT EXISTS (SELECT * FROM p_delivery_assignment WHERE driver_type = 'COMPANY');


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
#52 이슈 사항입니다.

-[x] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/#52_company-delivery-driver -> develop

### 변경 사항
- 업체 배송 담당자 지정 기능 구현
  - 허브 ID 전달 시 해당 허브 소속 업체 배송 담당자 정보 반환
  - 라운드로빈 방식으로 순차적 지정
    - 배정 인덱스가 배송 순번의 최댓값과 같으면 다음 배정 인덱스를 0으로 초기화
  - 담당자 지정 시 발생할 수 있는 동시성 이슈 제어를 위해 DB Pessimistic Lock 설정
    - SELECT ... FOR UPDATE를 사용하여 동일한 배송 담당자를 중복으로 배정하는 것을 방지
    - 다른 트랜잭션에서 접근할 수 없도록 하고, 현재 트랜잭션 완료 시 Lock 해제
- 다음 배송 담당자 지정을 위한 배정 인덱스 관리 테이블 추가
  - 해당 테이블의 Row에 Lock 설정
- 업체 배송 기사 추가 기능 구현
  - 배송 순번은 순번 값 중 가장 큰 값 + 1 또는 값이 없을 경우 0으로 초기화
- 업체 배송 기사 삭제 기능 구현